### PR TITLE
Fix specifying an action for an empty rule

### DIFF
--- a/r2/lib/Marpa/R2/Stuifzand.pm
+++ b/r2/lib/Marpa/R2/Stuifzand.pm
@@ -146,7 +146,7 @@ sub do_priority_rule {
 sub do_empty_rule {
     my ( undef, $lhs, undef, $adverb_list ) = @_;
     my $action = $adverb_list->{action};
-    return [ { lhs => $lhs, rhs => [], @{ $action || [] } } ];
+    return [ { lhs => $lhs, rhs => [], defined($action) ? (action => $action) : () } ];
 }
 
 sub do_quantified_rule {


### PR DESCRIPTION
Hi,

this code example that I think should work:

```
my $g = Marpa::R2::Grammar->new({
    actions => "main",
    start => "start",
    rules => "start ::= action => act"
});
$g->precompute;
my $r = Marpa::R2::Recognizer->new({grammar => $g});
print ${$r->value};
sub act { 123 }
```

actually dies with `Can't use string ("act") as an ARRAY ref while "strict refs" in use at .../Marpa/R2/Stuifzand.pm line 149.`

because the `do_empty_rule` action is doing something with the `$action` that doesn't make much in the way of sense. I've changed it to what I think it was trying to do, and this change makes my sample work and print "123".
