### PR TITLE
Make list of unproductive lexical symbols more readable

### DIFF
--- a/cpan/lib/Marpa/R2/MetaAST.pm
+++ b/cpan/lib/Marpa/R2/MetaAST.pm
@@ -131,7 +131,7 @@ sub ast_to_hash {
     $hashed_ast->{is_lexeme}  = \%is_lexeme;
 
     my @unproductive =
-        grep { not $lex_lhs{$_} and not $_ =~ /\A \[\[ /xms } (keys %lex_rhs,
+        map {"<$_>"} grep { not $lex_lhs{$_} and not $_ =~ /\A \[\[ /xms } (keys %lex_rhs,
         keys %lex_separator)
         ;
     if (@unproductive) {


### PR DESCRIPTION
Use case is the following.
Before:

Uncaught exception from user code:
        Unproductive lexical symbols: escape character character set specification simple value specification

After:
Uncaught exception from user code:
        Unproductive lexical symbols: <character set specification> <simple value specification> <escape character>
