### PR TITLE
Improve diag in Marpa::R2::Internal::MetaAST::new

### DIFF
--- a/cpan/lib/Marpa/R2/MetaAST.pm
+++ b/cpan/lib/Marpa/R2/MetaAST.pm
@@ -33,7 +33,8 @@ use English qw( -no_match_vars );
 sub new {
     my ( $class, $p_rules_source ) = @_;
     my $meta_recce = Marpa::R2::Internal::Scanless::meta_recce();
-    $meta_recce->read($p_rules_source);
+    eval { $meta_recce->read($p_rules_source) } or
+        Marpa::R2::exception("Parse of BNF/Scanless source failed\n", $EVAL_ERROR);
     if ( $meta_recce->ambiguity_metric() > 1 ) {
     my $asf = Marpa::R2::ASF->new( { slr => $meta_recce } );
     say STDERR 'No ASF' if not defined $asf;

--- a/cpan/t/sl_gia_err.t
+++ b/cpan/t/sl_gia_err.t
@@ -23,7 +23,7 @@ use 5.010;
 use strict;
 use warnings;
 
-use Test::More tests => 22;
+use Test::More tests => 24;
 use English qw( -no_match_vars );
 use lib 'inc';
 use Marpa::R2::Test;
@@ -105,6 +105,23 @@ Length of symbol "statement" at line 2, column 13 is ambiguous
   Choice 2 ending: uartet  ::= a a a a\n        start symbol is quartet
 END_OF_MESSAGE
     'English start statement second'
+];
+
+my $invalid_syntax_grammar = \(<<'END_OF_SOURCE');
+    quartet$ ::= a b c d e f
+END_OF_SOURCE
+
+push @tests_data, [
+    $invalid_syntax_grammar, 'n/a',
+    'SLIF grammar failed',
+    <<'END_OF_MESSAGE',
+Parse of BNF/Scanless source failed
+Error in SLIF parse: No lexeme found at line 1, column 12
+* String before error:     quartet
+* The error was at line 1, column 12, and at character 0x0024 '$', ...
+* here: $ ::= a b c d e f\n
+END_OF_MESSAGE
+    'Grammar with syntax error'
 ];
 
 #####


### PR DESCRIPTION
"Error in SLIF parse:..." exception was thrown when parsing both the input and the grammar source. It is now prepended with a line to show that the parse error occurred in the grammar source.
