### PR TITLE
fix indefinite articles

### DIFF
--- a/cpan/libmarpa/dev/api.texi
+++ b/cpan/libmarpa/dev/api.texi
@@ -4770,7 +4770,7 @@ Suggested message: "The recognizer has been started".
 @end deftypevr
 
 @deftypevr Macro int MARPA_ERR_RHS_IX_NEGATIVE
-The index of a RHS symbol was specified,
+The index of an RHS symbol was specified,
 and it was negative.
 That is not allowed.
 Numeric value: 63.

--- a/cpan/libmarpa/dev/marpa.w
+++ b/cpan/libmarpa/dev/marpa.w
@@ -2295,7 +2295,7 @@ are either shorter than
 a small constant in length, or
 else shorter than the XRL which is their
 source.
-On a 32-bit machine, this still allows a RHS of over a billion
+On a 32-bit machine, this still allows an RHS of over a billion
 symbols.
 I believe
 by the time 64-bit machines become universal,

--- a/cpan/pod/ASF.pod
+++ b/cpan/pod/ASF.pod
@@ -430,7 +430,7 @@ partial: 1
 =for Marpa::R2::Display::End
 
 Requires exactly one argument, C<$rh_ix>, which must be the zero-based
-index of a RHS child of the current rule instance.
+index of an RHS child of the current rule instance.
 Returns the value of the C<$rh_ix>'th child of the current rule instance.
 For convenient iteration,
 returns C<undef> if the value of the C<$rh_ix> is greater than or equal to the RHS length.

--- a/cpan/pod/Changes.pod
+++ b/cpan/pod/Changes.pod
@@ -254,7 +254,7 @@ a nulling symbol to be used as a terminal.
 To the extent that the Marpa::XS behavior made sense,
 it can be duplicated by creating a symbol which
 is the LHS of two rules, one empty,
-and the other rule with a RHS consisting of exactly one
+and the other rule with an RHS consisting of exactly one
 terminal symbol.
 
 =head2 A sequence must have a unique LHS

--- a/cpan/pod/Marpa_R2.pod
+++ b/cpan/pod/Marpa_R2.pod
@@ -466,11 +466,11 @@ When the non-leaf node is valued, its value becomes
 the value of its LHS symbol,
 and this value will become
 the value of
-a RHS symbol of another node with one
+an RHS symbol of another node with one
 exception.
 
 The one exception, the node with a LHS symbol
-that does not become a RHS
+that does not become an RHS
 symbol,
 is the value of the top (or "root") node.
 The value of the top node becomes the
@@ -527,7 +527,7 @@ that is, the value corresponding to the first symbol of the rule's RHS.
 The other way we specify semantics in this example
 is by using an
 C<action> adverb
-for a RHS alternative.
+for an RHS alternative.
 We've seen the C<action> adverb twice, but skipped over it.
 Now it is time to look at it.
 

--- a/cpan/pod/NAIF/Semantics/Order.pod
+++ b/cpan/pod/NAIF/Semantics/Order.pod
@@ -197,7 +197,7 @@ arbitrary.
 
 =head2 Null variant ranking
 
-Some rules have a RHS which contains
+Some rules have an RHS which contains
 B<proper nullables>:
 symbols
 which may be nulled, but which are not nulling

--- a/cpan/pod/Progress.pod
+++ b/cpan/pod/Progress.pod
@@ -618,7 +618,7 @@ That's fine, but why no other, more relevant, occurrences of C<E<lt>numeric expr
 
 We look back at the grammar.
 Aside for the rule for the 'C<string>' operator,
-C<E<lt>numeric expressionE<gt>> occurs on a RHS in two places.
+C<E<lt>numeric expressionE<gt>> occurs on an RHS in two places.
 One is in the prioritized rule which defines
 C<E<lt>numeric expressionE<gt>>.
 

--- a/cpan/pod/Scanless/DSL.pod
+++ b/cpan/pod/Scanless/DSL.pod
@@ -266,7 +266,7 @@ normalize-whitespace: 1
 =for Marpa::R2::Display::End
 
 A character class in square brackets ("C<[]>")
-can be used in a RHS alternative of a prioritized rule,
+can be used in an RHS alternative of a prioritized rule,
 a quantified rule or a discard rule.
 Marpa character classes may contain anything acceptable to Perl,
 and follow the same escaping conventions as Perl's character classes.
@@ -359,8 +359,8 @@ the right side declaration is described in detail below.
 
 The right side declaration of a rule will often contain one or
 more RHS alternatives.
-A RHS alternative is a series of RHS primaries,
-where a RHS primary may be a symbol name,
+An RHS alternative is a series of RHS primaries,
+where an RHS primary may be a symbol name,
 a character class,
 or a single quoted string.
 Associated with each RHS is often
@@ -455,7 +455,7 @@ Start rules must be G1 rules.
 =head2 Empty rules
 
 An empty rule is a rule with an empty RHS.
-The empty RHS, technically, is a RHS alternative, one with zero RHS primaries.
+The empty RHS, technically, is an RHS alternative, one with zero RHS primaries.
 The L<C<action>|/"action"> and
 L<C<bless>|/"bless"> adverbs are allowed 
 for the empty RHS alternative,
@@ -1119,7 +1119,7 @@ Marpa's precedence parsing is NOT based on
 the special treatment of operators.
 
 For the purpose of precedence,
-an operand is an occurrence in a RHS alternative
+an operand is an occurrence in an RHS alternative
 of the LHS symbol.
 An operator is considered to be anything 
 that is not an operand.

--- a/cpan/pod/Semantics.pod
+++ b/cpan/pod/Semantics.pod
@@ -283,7 +283,7 @@ L<the lexeme default statement|Marpa::R2::Scanless::DSL/"Lexeme default statemen
 =head2 Rule actions
 
 The implicit action for a rule instance is to return a Perl C<undef>.
-An explicit action for a RHS alternative can be specified using
+An explicit action for an RHS alternative can be specified using
 L<the C<action> adverb|Marpa::R2::Scanless::DSL/"action">
 for the its RHS alternative.
 A default explicit action for RHS alternatives can be specified with a
@@ -407,7 +407,7 @@ The C<::lhs> blessing is most useful in a default pseudo-rule.
 The lexeme
 is blessed into
 a class whose name is based on the name of the lexeme.
-The C<::name> blessing is not allowed for a RHS alternative.
+The C<::name> blessing is not allowed for an RHS alternative.
 
 The class is derived from the symbol name in the same way,
 and subject to the same restrictions,

--- a/cpan/pod/Semantics/Order.pod
+++ b/cpan/pod/Semantics/Order.pod
@@ -185,7 +185,7 @@ from two different DSL rules.
 
 =head2 Null variant ranking
 
-Some rules have a RHS which contains
+Some rules have an RHS which contains
 B<proper nullables>:
 symbols
 which may be nulled, but which are not nulling


### PR DESCRIPTION
R in RHS starts with a vowel sound, hence s/a RHS/an RHS/ as per http://www.grammar-monster.com/glossary/vowels.htm
