### PR TITLE
silence (most of) -ansi -pedantic warnings for XS compile

### DIFF
--- a/cpan/inc/Marpa/R2/Build_Me.pm
+++ b/cpan/inc/Marpa/R2/Build_Me.pm
@@ -250,7 +250,7 @@ sub process_xs {
     if ( $self->config('ccname') eq 'gcc' ) {
         ## -W instead of -Wextra is case the GCC is pre 3.0.0
         ## -Winline omitted because too noisy
-        push @new_ccflags, qw( -Wall -W -ansi
+        push @new_ccflags, qw( -Wall -W -ansi -pedantic -DPERL_GCC_PEDANTIC
             -Wpointer-arith -Wstrict-prototypes -Wwrite-strings
             -Wmissing-declarations );
         push @new_ccflags, '-Wdeclaration-after-statement' if gcc_is_at_least('3.4.6');


### PR DESCRIPTION
per [Nicholas Crask advice](http://grokbase.com/t/perl/xs/064dnbcrt1/quieting-pedantic-warnings). 

Warnings left:

In file included from lib/Marpa/R2.xs:18:0:
/usr/lib/perl5/5.14/i686-cygwin-threads-64int/CORE/config.h:4263:22: warning: ISO C90 does not support ‘long long’ [-Wlong-long]
 #define IVTYPE  long long  /**/
                      ^
/usr/lib/perl5/5.14/i686-cygwin-threads-64int/CORE/perl.h:1713:9: note: in expansion of macro ‘IVTYPE’
 typedef IVTYPE IV;
         ^
/usr/lib/perl5/5.14/i686-cygwin-threads-64int/CORE/config.h:4264:31: warning: ISO C90 does not support ‘long long’ [-Wlong-long]
 #define UVTYPE  unsigned long long  /**/
                               ^
/usr/lib/perl5/5.14/i686-cygwin-threads-64int/CORE/perl.h:1714:9: note: in expansion of macro ‘UVTYPE’
 typedef UVTYPE UV;
         ^
