### PR TITLE
refactor Cartesian product code to sub: displays+

### DIFF
--- a/cpan/lib/Marpa/R2/ASF.pm
+++ b/cpan/lib/Marpa/R2/ASF.pm
@@ -1360,6 +1360,25 @@ sub Marpa::R2::ASF::traverse {
     return $method->( $traverser, $per_traverse_object );
 } ## end sub Marpa::R2::ASF::traverse
 
+sub Marpa::R2::Internal::ASF::Traverse::all_choices {
+    my ( $traverser ) = @_;
+
+    my @values = Marpa::R2::Internal::ASF::Traverse::rh_values( $traverser );
+    my @results = ( [] );
+    for my $rh_ix ( 0 .. @values - 1 ) {
+        my @new_results = ();
+        for my $old_result (@results) {
+            my $child_value = $values[$rh_ix];
+            for my $new_value ( @{ $child_value } ) {
+                push @new_results, [ @{$old_result}, $new_value ];
+            }
+        }
+        @results = @new_results;
+    } ## end for my $rh_ix ( 0 .. $length - 1 )
+
+    return @results;
+}
+
 sub Marpa::R2::Internal::ASF::Traverse::literal {
     my ( $traverser ) = @_;
     my $asf = $traverser->[Marpa::R2::Internal::ASF::Traverse::ASF];

--- a/cpan/t/sl_panda1.t
+++ b/cpan/t/sl_panda1.t
@@ -125,18 +125,7 @@ sub full_traverser {
         # The parse results at each position are a list of choices, so
         # to produce a new result list, we need to take a Cartesian
         # product of all the choices
-        my @values = $glade->rh_values();
-        my @results = ( [] );
-        for my $rh_ix ( 0 .. @values - 1 ) {
-            my @new_results = ();
-            for my $old_result (@results) {
-                my $child_value = $values[$rh_ix];
-                for my $new_value ( @{ $child_value } ) {
-                    push @new_results, [ @{$old_result}, $new_value ];
-                }
-            }
-            @results = @new_results;
-        } ## end for my $rh_ix ( 0 .. $length - 1 )
+        my @results = $glade->all_choices();
 
         # Special case for the start rule: just collapse one level of lists
         if ( $symbol_name eq '[:start]' ) {


### PR DESCRIPTION
This is a followup to #106. Now that the displays in `sl_panda.t` are preserved and removed from `sl_panda1.t` (thanks!) and this patch won't break any, I'd like to re-submit it on the same grounds.
