### PR TITLE
call discard a pseudo-rule in the docs

### DIFF
--- a/cpan/pod/Scanless.pod
+++ b/cpan/pod/Scanless.pod
@@ -345,11 +345,11 @@ in a G1 rule, it still must be implemented at
 the L0 level.
 Marpa knows this and "does what you mean."
 
-=head2 Discard rules
+=head2 Discard pseudo-rules
 
 A new type of rule is introduced:
-a "discard" rule.
-A discard rule has a C<:discard> pseudo-symbol on its LHS
+a "discard" pseudo-rule.
+A discard pseudo-rule has a C<:discard> pseudo-symbol on its LHS
 and one symbol name on its RHS.
 It indicates that, when the RHS symbol is recognized,
 it should not be passed on as usual to the structural (G1) level.
@@ -381,7 +381,7 @@ So in practice I will usually simply refer to "lexemes".
 =head1 Longest tokens match
 
 The L0 grammar looks for tokens on a longest B<tokens> match basis.
-Tokens in discard rules are thrown away, and the rest are passed on
+Tokens in discard pseudo-rules are thrown away, and the rest are passed on
 to the G1 grammar.
 Note that match is longest TOKENS.
 There may be more than one longest match, in which case Marpa

--- a/cpan/pod/Scanless/DSL.pod
+++ b/cpan/pod/Scanless/DSL.pod
@@ -266,7 +266,7 @@ normalize-whitespace: 1
 
 A character class in square brackets ("C<[]>")
 can be used in a RHS alternative of a prioritized rule,
-a quantified rule or a discard rule.
+a quantified rule or a discard pseudo-rule.
 Marpa character classes may contain anything acceptable to Perl,
 and follow the same escaping conventions as Perl's character classes.
 
@@ -531,7 +531,7 @@ The single "or" symbol ("C<|>") is the ordinary "alternative" operator --
 alternatives on each side of it have the same priority.
 Associativity is specified using adverbs, as described below.
 
-=head2 Discard rules
+=head2 Discard pseudo-rules
 
 =for Marpa::R2::Display
 name: SLIF DSL synopsis
@@ -542,18 +542,18 @@ normalize-whitespace: 1
 
 =for Marpa::R2::Display::End
 
-A discard rule is a rule whose LHS is
+A discard pseudo-rule is a rule whose LHS is
 the C<:discard> pseudo-symbol,
 and which has only one RHS alternative.
 The RHS alternative must contain
 exactly one symbol name,
 called the B<discarded symbol>.
-Discard rules indicate that the discarded symbol is a top-level L0
+Discard pseudo-rules indicate that the discarded symbol is a top-level L0
 symbol, but one which is not a lexeme.
 When a discarded symbol is recognized,
 it is not passed as a lexeme to the G1 parser, but is
 (as the name suggests) discarded.
-Discard rules must be L0 rules.
+Discard pseudo-rules must be L0 rules.
 No adverbs are allowed.
 
 =head2 Default pseudo-rules


### PR DESCRIPTION
just like other pseudo-rules — `:lexeme` and `:default`.
