### PR TITLE
win32 fixes

### DIFF
--- a/cpan/libmarpa/win32/Makefile.win32
+++ b/cpan/libmarpa/win32/Makefile.win32
@@ -15,6 +15,11 @@
 
 # Build static and dynamic libraries of Marpa, using a config.h generated with Marpa::R2::Build_Me
 
+#
+# You should execute this Makefile in the libmarpa_dist directory like this:
+# nmake -f Makefile.win32
+#
+
 CC = cl
 CFLAGS = /c /Gy /DWIN32 /MD
 LD = link
@@ -23,29 +28,23 @@ CPFLAGS = /Y
 RM = del
 MT = mt
 RM_FLAGS = /Q
-PUSHD = pushd
-POPD = popd
-MARPA_DEF = marpa.def
+MARPA_DEF = win32\marpa.def
 MARPA_OBJS = marpa.obj marpa_ami.obj marpa_obs.obj marpa_avl.obj
 MARPA_DLL = libmarpa.dll
 
-LDFLAGS = /NOLOGO /SUBSYSTEM:CONSOLE /NODEFAULTLIB:"LIBCMTD.LIB" /DLL /DEF:$(MARPA_DEF) /VERSION:%MARPA_VERSION%
+LDFLAGS = /NOLOGO /SUBSYSTEM:CONSOLE /NODEFAULTLIB:"LIBCMTD.LIB" /DLL /DEF:$(MARPA_DEF) /VERSION:%%MARPA_VERSION%%
 
 .c.obj:
         $(CC) $(CFLAGS) /Fo$@ $<
 
-#
-# Trick to be able to run nmake in libmarpa_dist but build in libmarpa_build..
-#
-
 all: $(MARPA_DLL)
 
 $(MARPA_DLL): config.h $(MARPA_OBJS)
-        (@SET /p MARPA_VERSION= < VERSION) && $(LD) $(LDFLAGS) /OUT:$@ $(MARPA_OBJS)
+        $(LD) $(LDFLAGS) /OUT:$@ $(MARPA_OBJS)
         if exist $(MARPA_DLL).manifest mt -nologo -manifest $(MARPA_DLL).manifest -outputresource:$(MARPA_DLL);2
 
 config.h:
-        perl do_config_h.pl --cc="$(CC)" --ccflags="$(CFLAGS)" --obj_ext=".obj"
+        perl win32\do_config_h.pl --cc="$(CC)" --ccflags="$(CFLAGS)" --obj_ext=".obj"
 
 clean:
         $(RM) $(RM_FLAGS) *.obj

--- a/cpan/libmarpa/win32/do_config_h.pl
+++ b/cpan/libmarpa/win32/do_config_h.pl
@@ -140,7 +140,7 @@ sub do_config_h {
         
     if ($USE_PERL_AUTOCONF) {
 
-        my $libmarpa_version = read_file('VERSION');
+        my $libmarpa_version = read_file('LIB_VERSION');
         chomp $libmarpa_version;
         my @libmarpa_version = split /[.]/xms, $libmarpa_version;
 

--- a/cpan/libmarpa/win32/make.bat
+++ b/cpan/libmarpa/win32/make.bat
@@ -1,0 +1,2 @@
+SET /P MARPA_VERSION= <LIB_VERSION
+NMAKE -f Makefile.win32


### PR DESCRIPTION
Please note the new file make.bat
It appeared to be truely difficult to create an environment variable in DOS mungled by NMAKE and continue in the same shell
Simplest was to have dynamic variable setted in a bat file which then runs the nmake
