### PR TITLE
Fix 'trace_earley_sets'

### DIFF
--- a/cpan/lib/Marpa/R2/Recognizer.pm
+++ b/cpan/lib/Marpa/R2/Recognizer.pm
@@ -769,7 +769,7 @@ sub Marpa::R2::Recognizer::earleme_complete {
         print {$Marpa::R2::Internal::TRACE_FH} "=== Earley set $latest_set\n"
             or Marpa::R2::exception("Cannot print: $ERRNO");
         print {$Marpa::R2::Internal::TRACE_FH}
-            Marpa::R2::show_earley_set($latest_set)
+            Marpa::R2::show_earley_set($recce, $latest_set)
             or Marpa::R2::exception("Cannot print: $ERRNO");
     } ## end if ( $recce->[Marpa::R2::Internal::Recognizer::TRACE_EARLEY_SETS...])
 


### PR DESCRIPTION
The first argument to `show_earley_set` is the recognizer; this hasn't
worked since at least Marpa::XS before 96e06ad8e34bb