### PR TITLE
Issue #268: utf8::upgrade(), as perldoc utf8 says this makes \w "work…

### DIFF
--- a/cpan/lib/Marpa/R2/SLR.pm
+++ b/cpan/lib/Marpa/R2/SLR.pm
@@ -1062,6 +1062,8 @@ sub Marpa::R2::Scanless::R::resume {
             for my $entry ( @{$character_class_table} ) {
 
                 my ( $symbol_id, $re ) = @{$entry};
+                use utf8;                      # this is scoped
+                utf8::upgrade($character);
                 if ( $character =~ $re ) {
 
                     if ( $trace_terminals >= 2 ) {


### PR DESCRIPTION
… as Unicode on strings containing characters in the range 0x80-0xFF"