### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: perl
+perl:
+  - "5.26"
+  - "5.24"
+  - "5.24-shrplib"  # at least one perl with threading support
+  - "5.10"  # minimum supported version
+
+# install prerequisites
+install:
+  # for debugging, output available perls
+  - perlbrew list
+  # install dependencies without testing, for speed
+  - (cd cpan/ && cpanm --installdeps --quiet --notest .)
+
+# build Marpa and execute tests
+script:
+  - (cd cpan/xs/ && make)  # generate necessary files
+  - (cd cpan/ && perl Build.PL)
+  - (cd cpan/ && ./Build)
+  - (cd cpan/ && ./Build test)
+
+sudo: false  # faster builds using containers


### PR DESCRIPTION
This is basically the same config as for Marpa::R3, except for the build system.

There was a small surprise in that XS files have to be generated before the build will succeed: `cd cpan/xs; make`. I think the build can generate these files itself if invoked correctly. How do I do that and where is this documented? For now, the .travis.yml generates those files itself, which works fine.